### PR TITLE
Update xmodem.c

### DIFF
--- a/xmodem.c
+++ b/xmodem.c
@@ -139,7 +139,7 @@ int xmodemReceive(unsigned char *dest, int destsz)
 			*p++ = c;
 		}
 
-		if (xbuff[1] == (unsigned char)(~xbuff[2]) && 
+		if (xbuff[1] == (unsigned char)((~xbuff[2]) & 0xFF) && /* DSP is 16 bits wide so it need to &0xFF*/
 			(xbuff[1] == packetno || xbuff[1] == (unsigned char)packetno-1) &&
 			check(crc, &xbuff[3], bufsz)) {
 			if (xbuff[1] == packetno)	{
@@ -212,7 +212,7 @@ int xmodemTransmit(unsigned char *src, int srcsz)
 			xbuff[0] = SOH; bufsz = 128;
 #endif
 			xbuff[1] = packetno;
-			xbuff[2] = ~packetno;
+			xbuff[2] = (~packetno) & 0xFF; /* DSP is 16 bits wide so it need to &0xFF*/
 			c = srcsz - len;
 			if (c > bufsz) c = bufsz;
 			if (c > 0) {

--- a/xmodem.c
+++ b/xmodem.c
@@ -48,6 +48,16 @@
 #define MAXRETRANS 25
 #define TRANSMIT_XMODEM_1K
 
+int _inbyte(unsigned short timeout)
+{
+	// if timeout return < 0, if get data return data
+}
+
+void _outbyte(int c)
+{
+	
+}
+
 static int check(int crc, const unsigned char *buf, int sz)
 {
 	if (crc) {
@@ -139,7 +149,7 @@ int xmodemReceive(unsigned char *dest, int destsz)
 					memcpy (&dest[len], &xbuff[3], count);
 					len += count;
 				}
-				++packetno;
+				if(++packetno % 256 == 0) packetno = 1;
 				retrans = MAXRETRANS+1;
 			}
 			if (--retrans <= 0) {
@@ -228,7 +238,7 @@ int xmodemTransmit(unsigned char *src, int srcsz)
 					if ((c = _inbyte(DLY_1S)) >= 0 ) {
 						switch (c) {
 						case ACK:
-							++packetno;
+							if(++packetno % 256 == 0) packetno = 1;
 							len += bufsz;
 							goto start_trans;
 						case CAN:


### PR DESCRIPTION
Add a sequence number check, where when the sequence number modulo 256 equals 0, it is re-assigned to 1. This is because Xmodem sequence numbers start from 1, and this approach allows for sending files larger than 255 kbytes.